### PR TITLE
Do not add surrounding brackets when length is not specified

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -76,7 +76,7 @@ class DDLGenerator {
 
     dataType(elem, options) {
 		    var varLenFunc = function (elem, options) {
-    			  return "(" + elem.length + ")";
+    			  return elem.length.length ? "(" + elem.length + ")" : "";
     		}
     		var noLenFunc = function (elem, options) {
     			return "";


### PR DESCRIPTION
For example, a NUMERIC type without length specified previously returned "NUMERIC()", but will now return "NUMERIC"