### PR TITLE
Fixed Owner field type typo - Fixes #20

### DIFF
--- a/preferences/preference.json
+++ b/preferences/preference.json
@@ -9,7 +9,7 @@
     "psqlddl.gen.owner": {
       "text": "Owner name",
       "description": "Postgresql objects owner name",
-      "type": "String",
+      "type": "string",
       "default": "postgres"
     },
     "psqlddl.gen.tablespace": {


### PR DESCRIPTION
Owner field had type `String` instead of `string`.